### PR TITLE
changed pip3 upgrade to work, & fixed path

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
 source venv/bin/activate
-pip3 install --upgrade pip3
+pip3 install --upgrade pip
 pip3 install -r requirements.txt
 python3 -m unittest

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,4 @@
 source venv/bin/activate
-pip3 install --upgrade pip3
+pip3 install --upgrade pip
 pip3 install -r requirements.txt
-python3 gift-app/app.py
-
+python3 app.py


### PR DESCRIPTION
The pip3 --upgrade line was failing for me cause I guess pip3 isn't a valid module/package?, so I needed to change it to look for just pip.
https://stackoverflow.com/questions/39129450/what-is-the-correct-format-to-upgrade-pip3-when-the-default-pip-is-pip2

Also, fixed the path to app.py since you removed the enclosing gift-app folder.